### PR TITLE
fixes conflicts with arrays in old source code that causes ledFrames to not load in

### DIFF
--- a/traxplayer/html5/src/ui/TraxPlayerUi.ts
+++ b/traxplayer/html5/src/ui/TraxPlayerUi.ts
@@ -34,7 +34,7 @@ export class TraxPlayerUi implements PlayerListener {
   private isPlaying = false;
 
   constructor(private options: TraxPlayerUiOptions) {
-    this.ledFrames = Array.from({ length: 53 }, (_item, index) =>
+    this.ledFrames = Array(53).fill(0).map((_item, index) =>
       this.asset(`flash/sprites/DefineSprite_48/${index + 1}.png`)
     );
     this.playImage = this.asset('flash/buttons/DefineButton2_51/1.png');


### PR DESCRIPTION
fixes conflicts with arrays in old source code (in havana)(and probably other old cms's that use the same files) and causes ledFrames to not load in proper. 

`<img class="trax-led" data-role="led" src="undefined" alt="">`
`[Error] Failed to load resource: the server responded with a status of 404 (Not Found) (undefined, line 0)`
